### PR TITLE
added virtual void ActualRestart() to override in child classes

### DIFF
--- a/Protothread.h
+++ b/Protothread.h
@@ -64,7 +64,7 @@ public:
     Protothread() : _ptLine(0) { }
 
     // Restart protothread.
-    void Restart() { _ptLine = 0; }
+    void Restart() { _ptLine = 0; ActualRestart(); }
 
     // Stop the protothread from running. Happens automatically at PT_END.
     // Note: this differs from the Dunkels' original protothread behaviour
@@ -81,6 +81,8 @@ public:
     virtual bool Run() = 0;
 
 protected:
+	virtual void ActualRestart() {};
+
     // Used to store a protothread's position (what Dunkels calls a
     // "local continuation").
     typedef unsigned short LineNumber;


### PR DESCRIPTION
Consider the following code.
After runing this thread to the end and restarting it step should be set to 0. So I have provided 
`protected virtual ActualRestart()` 
to override it in derived class to be able to reset thread to it's initial state.

```
class MyThread: public Protothread {
public:
	MyThread(const char* n, int steps): name(n), max(steps){};
protected:
	virtual bool ActualRun() {
		std::cout << name << ": " << step << endl;
		step++;
		PT_BEGIN();
		PT_WAIT_WHILE(step<max);
		PT_END();
	}
	virtual void ActualRestart() {
		step=0;
	}
private:
	int step=0;
	int max=0;
	const char* name;
};
```