### PR TITLE
Added virtual ActualRun()

### DIFF
--- a/Protothread.h
+++ b/Protothread.h
@@ -75,12 +75,19 @@ public:
     // ended or exited.
     bool IsRunning() { return _ptLine != LineNumberInvalid; }
 
+	// Check if thread has not finished yet
+	virtual bool Run() {
+		if (IsRunning())
+			return ActualRun();
+		return false;
+	}
+
+protected:
     // Run next part of protothread or return immediately if it's still
     // waiting. Return true if protothread is still running, false if it
     // has finished. Implement this method in your Protothread subclass.
-    virtual bool Run() = 0;
+	virtual bool ActualRun()=0;
 
-protected:
     // Used to store a protothread's position (what Dunkels calls a
     // "local continuation").
     typedef unsigned short LineNumber;

--- a/Protothread.h
+++ b/Protothread.h
@@ -76,7 +76,7 @@ public:
     bool IsRunning() { return _ptLine != LineNumberInvalid; }
 
 	// Check if thread has not finished yet
-	virtual bool Run() {
+ bool Run() {
 		if (IsRunning())
 			return ActualRun();
 		return false;


### PR DESCRIPTION
Changed Run method to check if thread has not finished yet and need to be run.
Consider the following code:
```
class MyThread: public Protothread {
public:
	MyThread(const char* n, int steps): name(n), max(steps){};
protected:
	virtual bool ActualRun() {
		std::cout << name << ": " << step << endl;
		step++;
		PT_BEGIN();
		PT_WAIT_WHILE(step<max);
		PT_END();
	}
	virtual void ActualRestart() {
		step=0;
	}
private:
	int step=0;
	int max=0;
	const char* name;
};

int main()
{
	MyThread t2 = MyThread("t2", 5);
	while(true) {
		t2.Run();
	}
```

Without ActualRun() this code will output infinite number of lines:
```
t2: 0
t2: 1
t2: 2
t2: 3
t2: 4
t2: 5
and so on
```

With virtual bool ActualRun() the Run() method will check if the thread is still needs to be run and the output will be:
```
t2: 0
t2: 1
t2: 2
t2: 3
t2: 4
```


